### PR TITLE
Disabled rev signals

### DIFF
--- a/src/main/java/frc/lib/generic/hardware/motor/hardware/rev/GenericSparkBase.java
+++ b/src/main/java/frc/lib/generic/hardware/motor/hardware/rev/GenericSparkBase.java
@@ -352,6 +352,11 @@ public abstract class GenericSparkBase extends Motor {
         signalsConfig.iAccumulationPeriodMs(disabledMs);
         signalsConfig.iAccumulationAlwaysOn(false);
 
+        signalsConfig.setpointPeriodMs(disabledMs);
+        signalsConfig.isAtSetpointPeriodMs(disabledMs);
+        signalsConfig.selectedSlotPeriodMs(disabledMs);
+        signalsConfig.maxMotionSetpointPositionPeriodMs(disabledMs);
+        signalsConfig.maxMotionSetpointVelocityPeriodMs(disabledMs);
         signalsConfig.setSetpointAlwaysOn(false);
         signalsConfig.isAtSetpointAlwaysOn(false);
         signalsConfig.selectedSlotAlwaysOn(false);


### PR DESCRIPTION
disabled new rev signals
solves #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved motor controller bus efficiency by disabling additional unnecessary signal transmissions, reducing CAN bus traffic.
  * Expected result: lower communication load leading to slightly improved responsiveness and more reliable motor command delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->